### PR TITLE
Fixed an issue where calling WebApplication.Dispose() would cause a S…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Using the WebApiContrib StructureMap container is easy.
 
     var config = GlobalConfiguration.Configuration;
     var container = GetYourOwnBuiltContainer(); // You build this up yourself.
-    config.ServiceResolver.SetServiceResolver(new StructureMapResolver(container);
+    config.DependencyResolver = new StructureMapResolver(container);
 
 One thing that is unique about this resolver is that it is also an instance of IHttpControllerActivator. Upon creation of the StructureMapResolver, it injects itself as the object to be returned when IHttpControllerActivator is requested.
 

--- a/src/WebApiContrib.IoC.StructureMap/StructureMapResolver.cs
+++ b/src/WebApiContrib.IoC.StructureMap/StructureMapResolver.cs
@@ -39,9 +39,6 @@ namespace WebApiContrib.IoC.StructureMap
 
         public void Dispose()
         {
-            if (container != null)
-                container.Dispose();
-            
             container = null;
         }
     }

--- a/test/WebApiContrib.IoC.StructureMap.Tests/DependencyInjectionTests.cs
+++ b/test/WebApiContrib.IoC.StructureMap.Tests/DependencyInjectionTests.cs
@@ -1,6 +1,8 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Net.Http;
 using System.Web.Http;
+using Moq;
 using NUnit.Framework;
 using Should;
 using StructureMap;
@@ -76,6 +78,44 @@ namespace WebApiContrib.IoC.StructureMap.Tests.IoC
             var repositories = config.DependencyResolver.GetServices(typeof(IContactRepository));
 
             repositories.Count().ShouldEqual(0);
+        }
+
+        [Test]
+        public void StructureMapResolver_should_not_dispose_container()
+        {
+            var mockContainer = new Mock<IContainer>();
+
+            var resolver = new StructureMapResolver(mockContainer.Object);
+
+            resolver.Dispose();
+
+            mockContainer.Verify(c => c.Dispose(), Times.Never, "Should not have called Dispose on the container.");
+        }
+
+        [Test]
+        public void StructureMapResolver_should_throw_when_attempting_to_get_service_after_being_disposed()
+        {
+            var mockContainer = new Mock<IContainer>();
+
+            var resolver = new StructureMapResolver(mockContainer.Object);
+
+            resolver.Dispose();
+
+            Assert.That(() => resolver.GetService(typeof (IContactRepository)),
+                Throws.Exception.TypeOf<ObjectDisposedException>());
+        }
+
+        [Test]
+        public void StructureMapResolver_should_throw_when_attempting_to_get_services_after_being_disposed()
+        {
+            var mockContainer = new Mock<IContainer>();
+
+            var resolver = new StructureMapResolver(mockContainer.Object);
+
+            resolver.Dispose();
+
+            Assert.That(() => resolver.GetServices(typeof(IContactRepository)),
+                Throws.Exception.TypeOf<ObjectDisposedException>());
         }
     }
 }

--- a/test/WebApiContrib.IoC.StructureMap.Tests/WebApiContrib.IoC.StructureMap.Tests.csproj
+++ b/test/WebApiContrib.IoC.StructureMap.Tests/WebApiContrib.IoC.StructureMap.Tests.csproj
@@ -37,6 +37,10 @@
       <Private>True</Private>
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
+    <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.4.5.8\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/test/WebApiContrib.IoC.StructureMap.Tests/packages.config
+++ b/test/WebApiContrib.IoC.StructureMap.Tests/packages.config
@@ -3,6 +3,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebApi.Core" version="4.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />
+  <package id="Moq" version="4.2.1507.0118" targetFramework="net4" />
   <package id="Newtonsoft.Json" version="4.5.8" targetFramework="net40" />
   <package id="NUnit" version="2.6.1" targetFramework="net40" />
   <package id="NUnit.Runners" version="2.6.0.12051" />


### PR DESCRIPTION
…tackOverflowException to be thrown. StructureMapResolver was disposing the IContainer instance that it does not own. Updated readme.md for new SignalR syntax.
